### PR TITLE
Select schema to validate based on data version

### DIFF
--- a/kcidb_io/schema/v1.py
+++ b/kcidb_io/schema/v1.py
@@ -1,5 +1,6 @@
 """Kernel CI reporting I/O schema v1"""
 
+import re
 from kcidb_io.schema.misc import Version
 
 # Major version number of JSON schema.
@@ -535,6 +536,38 @@ JSON = {
     ]
 }
 
+
+def get_version(data):
+    """
+    Retrieve the schema version from a data.
+
+    Args:
+        data:   The data to retrieve the schema version from.
+
+    Returns:
+        The major and the minor schema version numbers from the data,
+        or (None, None), if not found.
+    """
+    try:
+        version = data["version"]
+        if isinstance(version, str):
+            match = re.match("^([0-9]+)(\\.([0-9]+))?$", version)
+            if match:
+                return int(match.group(1)), int(match.group(3) or "0")
+        else:
+            major = version["major"]
+            try:
+                minor = version["minor"]
+            except KeyError:
+                minor = 0
+            if isinstance(major, int) and isinstance(minor, int) and \
+               major >= 0 and minor >= 0:
+                return major, minor
+    except (TypeError, KeyError, ValueError):
+        pass
+    return None, None
+
+
 # The parent-child relationship tree
 TREE = {
     "": ["revisions"],
@@ -543,6 +576,7 @@ TREE = {
     "tests": []
 }
 
-VERSION = Version(JSON_VERSION_MAJOR, JSON_VERSION_MINOR, JSON, TREE)
+VERSION = Version(JSON_VERSION_MAJOR, JSON_VERSION_MINOR, JSON, TREE,
+                  get_version)
 
 __all__ = ["VERSION"]

--- a/kcidb_io/schema/v2.py
+++ b/kcidb_io/schema/v2.py
@@ -511,6 +511,26 @@ JSON = {
 }
 
 
+def get_version(data):
+    """
+    Retrieve the schema version from a data.
+
+    Args:
+        data:   The data to retrieve the schema version from.
+
+    Returns:
+        The major and the minor schema version numbers from the data,
+        or (None, None), if not found.
+    """
+    try:
+        version = data["version"]
+        if isinstance(version, dict):
+            return v1.VERSION.get_version(data)
+    except (TypeError, KeyError):
+        pass
+    return None, None
+
+
 def inherit(data):
     """
     Inherit data, i.e. convert data adhering to the previous version of
@@ -563,7 +583,8 @@ TREE = {
     "tests": []
 }
 
+
 VERSION = Version(JSON_VERSION_MAJOR, JSON_VERSION_MINOR, JSON, TREE,
-                  v1.VERSION, inherit)
+                  get_version, v1.VERSION, inherit)
 
 __all__ = ["VERSION"]

--- a/kcidb_io/schema/v3.py
+++ b/kcidb_io/schema/v3.py
@@ -649,6 +649,6 @@ TREE = {
 }
 
 VERSION = Version(JSON_VERSION_MAJOR, JSON_VERSION_MINOR, JSON, TREE,
-                  v2.VERSION, inherit)
+                  v2.VERSION.get_version, v2.VERSION, inherit)
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
Instead of simply just trying to validate against every schema version
in turn, try to get the data's version according to every schema version
in turn, and validate with only the one that's matching. If none match,
validate against the newest one.

This speeds up validation of data with older schemas, and simplifies
validation errors.

Fixes #1