### PR TITLE
Avoid validation when upgrading

### DIFF
--- a/kcidb_io/schema/misc.py
+++ b/kcidb_io/schema/misc.py
@@ -194,14 +194,11 @@ class Version:
         Returns:
             The upgraded and validated data.
         """
-        # Check for "previous" outside except block to avoid re-raising
-        if self.previous:
-            try:
-                data = self.validate_exactly(data)
-            except jsonschema.exceptions.ValidationError:
-                if copy:
-                    data = deepcopy(data)
-                data = self.previous.upgrade(data, copy=False)
-                if self.inherit:
-                    data = self.inherit(data)
+        if not self.is_compatible_exactly(data) and \
+           self.previous and self.previous.is_compatible(data):
+            if copy:
+                data = deepcopy(data)
+            data = self.previous.upgrade(data, copy=False)
+            if self.inherit:
+                data = self.inherit(data)
         return self.validate_exactly(data)


### PR DESCRIPTION
Similarly to the previous change to validation, avoid validation to
identify the compatible schema when upgrading, and check the version
numbers instead.