### PR TITLE
v4: Rename "description" fields to "comment"

### DIFF
--- a/kcidb_io/schema/test_v4.py
+++ b/kcidb_io/schema/test_v4.py
@@ -186,3 +186,66 @@ class UpgradeTestCase(unittest.TestCase):
         )
 
         self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)
+
+    def test_description_to_comment_rename(self):
+        """Check renaming 'description' to 'comment'"""
+        prev_version_data = dict(
+            version=dict(major=VERSION.previous.major,
+                         minor=VERSION.previous.minor),
+            revisions=[
+                dict(id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     origin="origin1",
+                     description="A revision with a comment"),
+                dict(id="a538920a149edf64f9022722eb48d680bfda6dc8",
+                     origin="origin1"),
+            ],
+            builds=[
+                dict(revision_id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     id="origin2:1",
+                     origin="origin2",
+                     description="A build with a comment"),
+                dict(revision_id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     id="origin3:2",
+                     origin="origin3"),
+            ],
+            tests=[
+                dict(build_id="origin2:1", id="origin4:1-1", origin="origin4",
+                     description="A test with a comment"),
+                dict(build_id="origin2:1", id="origin5:1-2", origin="origin5"),
+                dict(build_id="origin3:2", id="origin6:2-1", origin="origin6",
+                     description="Another test with a comment"),
+                dict(build_id="origin3:2", id="origin7:2-2", origin="origin7"),
+            ],
+        )
+        new_version_data = dict(
+            version=dict(major=VERSION.major,
+                         minor=VERSION.minor),
+            checkouts=[
+                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     origin="origin1",
+                     patchset_hash="",
+                     comment="A revision with a comment"),
+                dict(id="_:a538920a149edf64f9022722eb48d680bfda6dc8",
+                     origin="origin1",
+                     patchset_hash=""),
+            ],
+            builds=[
+                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     id="origin2:1",
+                     origin="origin2",
+                     comment="A build with a comment"),
+                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     id="origin3:2",
+                     origin="origin3"),
+            ],
+            tests=[
+                dict(build_id="origin2:1", id="origin4:1-1", origin="origin4",
+                     comment="A test with a comment"),
+                dict(build_id="origin2:1", id="origin5:1-2", origin="origin5"),
+                dict(build_id="origin3:2", id="origin6:2-1", origin="origin6",
+                     comment="Another test with a comment"),
+                dict(build_id="origin3:2", id="origin7:2-2", origin="origin7"),
+            ],
+        )
+
+        self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)

--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -190,10 +190,10 @@ JSON_CHECKOUT = {
                 "message with the applied patchset, or a release "
                 "announcement sent to a maillist.",
         },
-        "description": {
+        "comment": {
             "type": "string",
             "description":
-                "Human-readable description of the checkout. "
+                "A human-readable comment regarding the checkout. "
                 "E.g. the checked out release version, or the subject of the "
                 "message with the applied patchset."
         },
@@ -288,10 +288,10 @@ JSON_BUILD = {
                 "The name of the CI system which submitted the build",
             "pattern": f"^{ORIGIN_PATTERN}$",
         },
-        "description": {
+        "comment": {
             "type": "string",
             "description":
-                "Human-readable description of the build"
+                "A human-readable comment regarding the build"
         },
         "start_time": {
             "type": "string",
@@ -423,10 +423,10 @@ JSON_TEST = {
                 "amount of memory/storage/CPUs, for each host; "
                 "process environment variables, etc.",
             "properties": {
-                "description": {
+                "comment": {
                     "type": "string",
                     "description":
-                        "Human-readable description of the environment"
+                        "A human-readable comment regarding the environment."
                 },
                 "misc": {
                     "type": "object",
@@ -450,10 +450,10 @@ JSON_TEST = {
                 "ltp.sem01",
             ],
         },
-        "description": {
+        "comment": {
             "type": "string",
             "description":
-                "Human-readable description of the test run"
+                "A human-readable comment regarding the test run"
         },
         "status": {
             "type": "string",
@@ -640,6 +640,9 @@ def inherit(data):
             # Rename "discovery_time" to "start_time"
             if 'discovery_time' in revision:
                 revision['start_time'] = revision.pop('discovery_time')
+            # Rename 'description' to 'comment'
+            if 'description' in revision:
+                revision['comment'] = revision.pop('description')
         # Rename "revisions" to "checkouts"
         data['checkouts'] = data.pop('revisions')
 
@@ -647,6 +650,21 @@ def inherit(data):
     for build in data.get('builds', []):
         # Switch from revision IDs to checkout IDs
         build['checkout_id'] = "_:" + build.pop('revision_id')
+        # Rename 'description' to 'comment'
+        if 'description' in build:
+            build['comment'] = build.pop('description')
+
+    # Inherit tests
+    for test in data.get('tests', []):
+        # Rename 'description' to 'comment'
+        if 'description' in test:
+            test['comment'] = test.pop('description')
+        # Inherit environment
+        if 'environment' in test:
+            environment = test['environment']
+            # Rename 'description' to 'comment'
+            if 'description' in environment:
+                environment['comment'] = environment.pop('description')
 
     # Update version
     data['version'] = dict(major=JSON_VERSION_MAJOR,


### PR DESCRIPTION
Replace "description" with "comment" as the field containing any extra
explanation the submitter wants to attach to the object, with the intent
to show it alongside the generated description in reports/dashboards.

The "description" name means it describes the object overall. However we
have other fields describing them in detail, and we'd rather use that to
generate our own description, consistently, regardless of the submitter.

Fixes #10