### PR TITLE
v4: Add log_url/log_excerpt fields to tests

### DIFF
--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -234,7 +234,7 @@ JSON_CHECKOUT = {
             "type": "string",
             "format": "uri",
             "description":
-                "The URL of the log file of the checkout attempt. "
+                "The URL of a plain-text log file of the checkout attempt. "
                 "E.g. 'git am' output.",
         },
         "log_excerpt": {
@@ -364,7 +364,7 @@ JSON_BUILD = {
             "type": "string",
             "format": "uri",
             "description":
-                "The URL of the build log file.",
+                "The URL of the plain-text build log file.",
         },
         "log_excerpt": {
             "type": "string",

--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -493,6 +493,28 @@ JSON_TEST = {
             "description":
                 "A human-readable comment regarding the test run"
         },
+        "log_url": {
+            "type": "string",
+            "format": "uri",
+            "description":
+                "The URL of the plain-text test output or log file. "
+                "If the test produced multiple outputs/files, this should "
+                "point to the one containing the highest-level overview of "
+                "the test's operation. The rest should go into "
+                "\"output_files\"."
+        },
+        "log_excerpt": {
+            "type": "string",
+            "maxLength": 16384,
+            "description":
+                "A part of the test output/log file (which could be) "
+                "referenced by \"log_url\", most relevant to the test "
+                "outcome.",
+            "examples": [
+                "netns_breakns_ns_exec_ipv4_ioctl FAIL 2\n",
+                "kernel BUG at net/core/dev.c:2648!\n",
+            ],
+        },
         "status": {
             "type": "string",
             "description":
@@ -542,7 +564,8 @@ JSON_TEST = {
         "output_files": {
             "type": "array",
             "description":
-                "A list of test outputs: logs, dumps, etc.",
+                "A list of test outputs: logs, dumps, etc. "
+                "Except the file referenced by \"log_url\".",
             "items": JSON_RESOURCE,
         },
         "misc": {


### PR DESCRIPTION
Add "log_url" and "log_excerpt" fields to "tests".