### PR TITLE
v4: Add origin to inherited checkout IDs

### DIFF
--- a/kcidb_io/schema/test_v4.py
+++ b/kcidb_io/schema/test_v4.py
@@ -27,54 +27,56 @@ class UpgradeTestCase(unittest.TestCase):
                 dict(id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
                         "+01ba4719c80b6fe911b091a7c05124b64eeece9"
                         "64e09c058ef8f9805daca546b",
-                     origin="origin1")
+                     origin="origin2")
             ],
             builds=[
                 dict(revision_id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
-                     id="origin2:1",
-                     origin="origin2"),
+                     id="origin1:1",
+                     origin="origin1"),
                 dict(revision_id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
                                  "+01ba4719c80b6fe911b091a7c05124b64eeece9"
                                  "64e09c058ef8f9805daca546b",
-                     id="origin3:2",
-                     origin="origin3"),
+                     id="origin2:2",
+                     origin="origin2"),
             ],
             tests=[
-                dict(build_id="origin2:1", id="origin4:1-1", origin="origin4"),
-                dict(build_id="origin2:1", id="origin5:1-2", origin="origin5"),
-                dict(build_id="origin3:2", id="origin6:2-1", origin="origin6"),
-                dict(build_id="origin3:2", id="origin7:2-2", origin="origin7"),
+                dict(build_id="origin1:1", id="origin4:1-1", origin="origin4"),
+                dict(build_id="origin1:1", id="origin5:1-2", origin="origin5"),
+                dict(build_id="origin2:2", id="origin6:2-1", origin="origin6"),
+                dict(build_id="origin2:2", id="origin7:2-2", origin="origin7"),
             ],
         )
         new_version_data = dict(
             version=dict(major=VERSION.major,
                          minor=VERSION.minor),
             checkouts=[
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      origin="origin1",
                      patchset_hash=""),
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
+                dict(id="_:origin2:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
                         "+01ba4719c80b6fe911b091a7c05124b64eeece9"
                         "64e09c058ef8f9805daca546b",
                      patchset_hash="01ba4719c80b6fe911b091a7c05124b6"
                                    "4eeece964e09c058ef8f9805daca546b",
-                     origin="origin1")
+                     origin="origin2")
             ],
             builds=[
-                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
-                     id="origin2:1",
-                     origin="origin2"),
-                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
+                dict(checkout_id="_:origin1:"
+                                 "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     id="origin1:1",
+                     origin="origin1"),
+                dict(checkout_id="_:origin2:"
+                                 "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e"
                                  "+01ba4719c80b6fe911b091a7c05124b64eeece9"
                                  "64e09c058ef8f9805daca546b",
-                     id="origin3:2",
-                     origin="origin3"),
+                     id="origin2:2",
+                     origin="origin2"),
             ],
             tests=[
-                dict(build_id="origin2:1", id="origin4:1-1", origin="origin4"),
-                dict(build_id="origin2:1", id="origin5:1-2", origin="origin5"),
-                dict(build_id="origin3:2", id="origin6:2-1", origin="origin6"),
-                dict(build_id="origin3:2", id="origin7:2-2", origin="origin7"),
+                dict(build_id="origin1:1", id="origin4:1-1", origin="origin4"),
+                dict(build_id="origin1:1", id="origin5:1-2", origin="origin5"),
+                dict(build_id="origin2:2", id="origin6:2-1", origin="origin6"),
+                dict(build_id="origin2:2", id="origin7:2-2", origin="origin7"),
             ],
         )
 
@@ -105,7 +107,7 @@ class UpgradeTestCase(unittest.TestCase):
             version=dict(major=VERSION.major,
                          minor=VERSION.minor),
             checkouts=[
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      origin="origin1",
                      patchset_files=[
                          dict(name="0001.patch",
@@ -114,11 +116,11 @@ class UpgradeTestCase(unittest.TestCase):
                               url="https://example.com/0002.patch"),
                      ],
                      patchset_hash=""),
-                dict(id="_:6150cc0cf631fdf766321368464e9f403fef3428",
+                dict(id="_:origin2:6150cc0cf631fdf766321368464e9f403fef3428",
                      origin="origin2",
                      patchset_files=[],
                      patchset_hash=""),
-                dict(id="_:3f1c54e6d648205fa1e3d3b405740e0d162ea264",
+                dict(id="_:origin3:3f1c54e6d648205fa1e3d3b405740e0d162ea264",
                      origin="origin3",
                      patchset_hash="")
             ],
@@ -144,10 +146,10 @@ class UpgradeTestCase(unittest.TestCase):
             version=dict(major=VERSION.major,
                          minor=VERSION.minor),
             checkouts=[
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      origin="origin1",
                      patchset_hash=""),
-                dict(id="_:6150cc0cf631fdf766321368464e9f403fef3428+"
+                dict(id="_:origin2:6150cc0cf631fdf766321368464e9f403fef3428+"
                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e46"
                         "49b934ca495991b7852b855",
                      origin="origin2",
@@ -175,11 +177,11 @@ class UpgradeTestCase(unittest.TestCase):
             version=dict(major=VERSION.major,
                          minor=VERSION.minor),
             checkouts=[
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      origin="origin1",
                      patchset_hash="",
                      start_time="2020-08-14T23:08:06.967000+00:00"),
-                dict(id="_:3f1c54e6d648205fa1e3d3b405740e0d162ea264",
+                dict(id="_:origin2:3f1c54e6d648205fa1e3d3b405740e0d162ea264",
                      origin="origin2",
                      patchset_hash="")
             ],
@@ -221,20 +223,22 @@ class UpgradeTestCase(unittest.TestCase):
             version=dict(major=VERSION.major,
                          minor=VERSION.minor),
             checkouts=[
-                dict(id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      origin="origin1",
                      patchset_hash="",
                      comment="A revision with a comment"),
-                dict(id="_:a538920a149edf64f9022722eb48d680bfda6dc8",
+                dict(id="_:origin1:a538920a149edf64f9022722eb48d680bfda6dc8",
                      origin="origin1",
                      patchset_hash=""),
             ],
             builds=[
-                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(checkout_id="_:origin2:"
+                                 "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      id="origin2:1",
                      origin="origin2",
                      comment="A build with a comment"),
-                dict(checkout_id="_:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                dict(checkout_id="_:origin3:"
+                                 "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                      id="origin3:2",
                      origin="origin3"),
             ],

--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -665,8 +665,11 @@ def inherit(data):
     # Inherit revisions
     if 'revisions' in data:
         for revision in data['revisions']:
-            # Add placeholder origin to the ID
-            revision['id'] = '_:' + revision['id']
+            # Generate checkout ID from the origin and revision ID.
+            # Assume everyone sending older schema versions only uses their
+            # own revisions, and prevent losing most data to deduplication.
+            # Use placeholder origin to avoid clashes with actual checkouts.
+            revision['id'] = '_:' + revision['origin'] + ':' + revision['id']
             # Rename "patch_mboxes" to "patchset_files"
             if 'patch_mboxes' in revision:
                 revision['patchset_files'] = revision.pop('patch_mboxes')
@@ -686,8 +689,12 @@ def inherit(data):
 
     # Inherit builds
     for build in data.get('builds', []):
-        # Switch from revision IDs to checkout IDs
-        build['checkout_id'] = "_:" + build.pop('revision_id')
+        # Generate checkout ID from the origin and revision ID.
+        # Assume everyone sending older schema versions only uses their
+        # own revisions, and prevent losing most data to deduplication.
+        # Use placeholder origin to avoid clashes with actual checkouts.
+        build['checkout_id'] = '_:' + build['origin'] + ':' + \
+            build.pop('revision_id')
         # Rename 'description' to 'comment'
         if 'description' in build:
             build['comment'] = build.pop('description')


### PR DESCRIPTION
Add the revision/build origin to checkout IDs generated from inherited
data in v4 schema. This is assuming that no submitter using pre-v4
schema is referring to someone else's revisions, and prevents the loss
of most data to deduplication.