### PR TITLE
v4: Remove "publishing_time"

### DIFF
--- a/kcidb_io/schema/test_v4.py
+++ b/kcidb_io/schema/test_v4.py
@@ -189,6 +189,34 @@ class UpgradeTestCase(unittest.TestCase):
 
         self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)
 
+    def test_drop_publishing_time(self):
+        """Check revision's publishing_time is dropped appropriately"""
+        prev_version_data = dict(
+            version=dict(major=VERSION.previous.major,
+                         minor=VERSION.previous.minor),
+            revisions=[
+                dict(id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     origin="origin1",
+                     publishing_time="2020-08-14T23:08:06.967000+00:00"),
+                dict(id="3f1c54e6d648205fa1e3d3b405740e0d162ea264",
+                     origin="origin2"),
+            ],
+        )
+        new_version_data = dict(
+            version=dict(major=VERSION.major,
+                         minor=VERSION.minor),
+            checkouts=[
+                dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     origin="origin1",
+                     patchset_hash=""),
+                dict(id="_:origin2:3f1c54e6d648205fa1e3d3b405740e0d162ea264",
+                     origin="origin2",
+                     patchset_hash="")
+            ],
+        )
+
+        self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)
+
     def test_description_to_comment_rename(self):
         """Check renaming 'description' to 'comment'"""
         prev_version_data = dict(

--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -197,16 +197,6 @@ JSON_CHECKOUT = {
                 "E.g. the checked out release version, or the subject of the "
                 "message with the applied patchset."
         },
-        "publishing_time": {
-            "type": "string",
-            "format": "date-time",
-            "description":
-                "The time the checked out source code was made public. E.g. "
-                "the timestamp on a patch message, a commit, or a tag.",
-            "examples": [
-                "2020-08-14T23:08:06.967000+00:00",
-            ],
-        },
         "start_time": {
             "type": "string",
             "format": "date-time",
@@ -707,6 +697,8 @@ def inherit(data):
             # Rename 'description' to 'comment'
             if 'description' in revision:
                 revision['comment'] = revision.pop('description')
+            # Remove "publishing_time"
+            revision.pop('publishing_time', None)
         # Rename "revisions" to "checkouts"
         data['checkouts'] = data.pop('revisions')
 


### PR DESCRIPTION
Remove the "publishing_time" property from "checkouts", since nobody
uses it, and it became more confusing after the "revision"->"checkout"
rename.