### PR TITLE
schema: Do not assert data is valid when upgrading

### DIFF
--- a/kcidb_io/schema/misc.py
+++ b/kcidb_io/schema/misc.py
@@ -218,7 +218,6 @@ class Version:
                                                    or any of the previous
                                                    schema versions.
         """
-        assert LIGHT_ASSERTS or self.is_valid(data)
         if copy:
             data = deepcopy(data)
         if not self.is_compatible_exactly(data):


### PR DESCRIPTION
Do not assert the data supplied to
kcidb_io.schema.misc.Version.upgrade() is valid, as that prevents a more
readable error message when trying to upgrade newer schema version to
older schema version. The function validates the data at the end anyway.