### PR TITLE
schema: Rename tree to graph

### DIFF
--- a/kcidb_io/schema/test_abstract.py
+++ b/kcidb_io/schema/test_abstract.py
@@ -14,7 +14,7 @@ class VersionTestCase(unittest.TestCase):
             major = 1
             minor = 0
             json = dict(title="v1")
-            tree = {"": []}
+            graph = {"": []}
 
             @classmethod
             def _inherit(cls, data):
@@ -24,7 +24,7 @@ class VersionTestCase(unittest.TestCase):
             major = 2
             minor = 0
             json = dict(title="v2")
-            tree = {"": []}
+            graph = {"": []}
 
             @classmethod
             def _inherit(cls, data):
@@ -49,7 +49,7 @@ class VersionTestCase(unittest.TestCase):
                 major = 0
                 minor = 0
                 json = dict(title="v0")
-                tree = {"": []}
+                graph = {"": []}
 
                 @classmethod
                 def _inherit(cls, data):
@@ -60,14 +60,14 @@ class VersionTestCase(unittest.TestCase):
                 major = 1
                 minor = 0
                 json = dict(title="v1")
-                tree = {"": []}
+                graph = {"": []}
 
         with self.assertRaises(AssertionError):
             class V1WithInherit(Version):
                 major = 1
                 minor = 0
                 json = dict(title="v1")
-                tree = {"": []}
+                graph = {"": []}
 
                 @classmethod
                 def _inherit(cls, data):
@@ -77,14 +77,14 @@ class VersionTestCase(unittest.TestCase):
                 major = 2
                 minor = 0
                 json = dict(title="v2")
-                tree = {"": []}
+                graph = {"": []}
 
         with self.assertRaises(AssertionError):
-            class V1InvalidTree(Version):
+            class V1InvalidGraph(Version):
                 major = 1
                 minor = 0
                 json = dict(title="v1")
-                tree = {}
+                graph = {}
 
                 @classmethod
                 def _inherit(cls, data):
@@ -95,7 +95,7 @@ class VersionTestCase(unittest.TestCase):
                 major = 1
                 minor = 0
                 json = dict(title="v1")
-                tree = {"": []}
+                graph = {"": []}
 
                 @classmethod
                 def _inherit(cls, data):
@@ -105,7 +105,7 @@ class VersionTestCase(unittest.TestCase):
                 major = 1
                 minor = 0
                 json = dict(title="v1")
-                tree = {"": []}
+                graph = {"": []}
 
                 @classmethod
                 def _inherit(cls, data):
@@ -122,7 +122,7 @@ class VersionTestCase(unittest.TestCase):
             major = 1
             minor = 0
             json = dict(title="v1")
-            tree = {"": []}
+            graph = {"": []}
 
             @classmethod
             def _inherit(cls, data):
@@ -132,7 +132,7 @@ class VersionTestCase(unittest.TestCase):
             major = 2
             minor = 0
             json = dict(title="v2a")
-            tree = {"": []}
+            graph = {"": []}
 
             @classmethod
             def _inherit(cls, data):
@@ -142,7 +142,7 @@ class VersionTestCase(unittest.TestCase):
             major = 2
             minor = 0
             json = dict(title="v2b")
-            tree = {"": []}
+            graph = {"": []}
 
             @classmethod
             def _inherit(cls, data):

--- a/kcidb_io/schema/v1.py
+++ b/kcidb_io/schema/v1.py
@@ -572,8 +572,8 @@ class Version(AbstractVersion):
         ]
     }
 
-    # The parent-child relationship tree
-    tree = {
+    # The parent-child relationship graph
+    graph = {
         "": ["revisions"],
         "revisions": ["builds"],
         "builds": ["tests"],

--- a/kcidb_io/schema/v2.py
+++ b/kcidb_io/schema/v2.py
@@ -541,8 +541,8 @@ class Version(PreviousVersion):
         ]
     }
 
-    # The parent-child relationship tree
-    tree = {
+    # The parent-child relationship graph
+    graph = {
         "": ["revisions"],
         "revisions": ["builds"],
         "builds": ["tests"],

--- a/kcidb_io/schema/v3.py
+++ b/kcidb_io/schema/v3.py
@@ -623,8 +623,8 @@ class Version(PreviousVersion):
         ]
     }
 
-    # The parent-child relationship tree
-    tree = {
+    # The parent-child relationship graph
+    graph = {
         "": ["revisions"],
         "revisions": ["builds"],
         "builds": ["tests"],
@@ -645,7 +645,7 @@ class Version(PreviousVersion):
         """
         # Extract origins into separate fields
         origin_regex = re.compile(f"^({Version.origin_pattern}):.*")
-        for obj_list_name in super().tree:
+        for obj_list_name in super().graph:
             if obj_list_name:
                 for obj in data.get(obj_list_name, []):
                     obj["origin"] = origin_regex.search(obj["id"]).group(1)

--- a/kcidb_io/schema/v4.py
+++ b/kcidb_io/schema/v4.py
@@ -681,8 +681,8 @@ class Version(PreviousVersion):
         ],
     }
 
-    # The parent-child relationship tree
-    tree = {
+    # The parent-child relationship graph
+    graph = {
         "": ["checkouts"],
         "checkouts": ["builds"],
         "builds": ["tests"],

--- a/kcidb_io/schema/v5.py
+++ b/kcidb_io/schema/v5.py
@@ -681,8 +681,8 @@ class Version(PreviousVersion):
         ],
     }
 
-    # The parent-child relationship tree
-    tree = {
+    # The parent-child relationship graph
+    graph = {
         "": ["checkouts"],
         "checkouts": ["builds"],
         "builds": ["tests"],


### PR DESCRIPTION
Rename the "tree" property of schema versions to "graph" to prepare to nodes having more than one parent with the introduction of "issues" and "incidents".

Keep adding the "tree" alias until all users transition to "graph"