### PR TITLE
pylint: Disable errors about literal dicts

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=duplicate-code
+disable=duplicate-code,use-dict-literal
 
 [REPORTS]
 # Activate the evaluation score.


### PR DESCRIPTION
Disable pylint's `use-dict-literal` error, as we love using `dict()` for its brevity. We might measure performance later and switch to literals, if necessary.