### PR TITLE
Support stripping metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         runs-on: [ubuntu-latest]
-        include:
-          - python-version: "3.6"
-            runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/kcidb_io/schema/abstract.py
+++ b/kcidb_io/schema/abstract.py
@@ -61,24 +61,28 @@ class MetaVersion(ABCMeta):
             assert "" in cls.graph
 
     def __le__(cls, other):
-        if not issubclass(cls, other) and not issubclass(other, cls):
-            return NotImplemented
-        return issubclass(other, cls)
+        if isinstance(other, type) and \
+           (issubclass(cls, other) or issubclass(other, cls)):
+            return issubclass(other, cls)
+        return NotImplemented
 
     def __ge__(cls, other):
-        if not issubclass(cls, other) and not issubclass(other, cls):
-            return NotImplemented
-        return issubclass(cls, other)
+        if isinstance(other, type) and \
+           (issubclass(cls, other) or issubclass(other, cls)):
+            return issubclass(cls, other)
+        return NotImplemented
 
     def __lt__(cls, other):
-        if not issubclass(cls, other) and not issubclass(other, cls):
-            return NotImplemented
-        return issubclass(other, cls) and cls is not other
+        if isinstance(other, type) and \
+           (issubclass(cls, other) or issubclass(other, cls)):
+            return issubclass(other, cls) and cls is not other
+        return NotImplemented
 
     def __gt__(cls, other):
-        if not issubclass(cls, other) and not issubclass(other, cls):
-            return NotImplemented
-        return issubclass(cls, other) and cls is not other
+        if isinstance(other, type) and \
+           (issubclass(cls, other) or issubclass(other, cls)):
+            return issubclass(cls, other) and cls is not other
+        return NotImplemented
 
     @property
     def previous(cls):

--- a/kcidb_io/schema/abstract.py
+++ b/kcidb_io/schema/abstract.py
@@ -62,22 +62,22 @@ class MetaVersion(ABCMeta):
 
     def __le__(cls, other):
         if not issubclass(cls, other) and not issubclass(other, cls):
-            raise NotImplementedError
+            return NotImplemented
         return issubclass(other, cls)
 
     def __ge__(cls, other):
         if not issubclass(cls, other) and not issubclass(other, cls):
-            raise NotImplementedError
+            return NotImplemented
         return issubclass(cls, other)
 
     def __lt__(cls, other):
         if not issubclass(cls, other) and not issubclass(other, cls):
-            raise NotImplementedError
+            return NotImplemented
         return issubclass(other, cls) and cls is not other
 
     def __gt__(cls, other):
         if not issubclass(cls, other) and not issubclass(other, cls):
-            raise NotImplementedError
+            return NotImplemented
         return issubclass(cls, other) and cls is not other
 
     @property

--- a/kcidb_io/schema/test_abstract.py
+++ b/kcidb_io/schema/test_abstract.py
@@ -192,11 +192,11 @@ class VersionTestCase(unittest.TestCase):
         self.assertFalse(V1 > V2A)
         self.assertFalse(V1 > V2B)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.assertTrue(V2A < V2B)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.assertTrue(V2A > V2B)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.assertTrue(V2A <= V2B)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.assertTrue(V2A >= V2B)

--- a/kcidb_io/schema/test_v04_03.py
+++ b/kcidb_io/schema/test_v04_03.py
@@ -1,0 +1,72 @@
+"""v04_03 module tests"""
+
+from kcidb_io.schema.v04_03 import Version
+
+
+def test_has_metadata():
+    """Check has_metadata() works correctly"""
+    assert not Version.has_metadata(Version.new())
+    assert not Version.has_metadata(dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="")
+        ]
+    ))
+    assert not Version.has_metadata(dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="",
+                 misc=dict(_timestamp="2023-11-06T11:58:15.163000+00:00"))
+        ]
+    ))
+    assert Version.has_metadata(dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="",
+                 _timestamp="2023-11-06T11:58:15.163000+00:00"),
+        ]
+    ))
+
+
+def test_strip_metadata():
+    """Check strip_metadata() works correctly"""
+    assert Version.strip_metadata(Version.new()) == Version.new()
+
+    io_without_metadata = dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="")
+        ]
+    )
+    assert Version.strip_metadata(io_without_metadata) == io_without_metadata
+
+    io_with_misc_metadata = dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="",
+                 misc=dict(_timestamp="2023-11-06T11:58:15.163000+00:00"))
+        ]
+    )
+    assert Version.strip_metadata(io_with_misc_metadata) == \
+        io_with_misc_metadata
+
+    io_with_metadata = dict(
+        version=dict(major=Version.major, minor=Version.minor),
+        checkouts=[
+            dict(id="_:origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                 origin="origin1",
+                 patchset_hash="",
+                 _timestamp="2023-11-06T11:58:15.163000+00:00"),
+        ]
+    )
+    assert Version.strip_metadata(io_with_metadata) == io_without_metadata


### PR DESCRIPTION
This adds support for stripping metadata from I/O data. There's no real need for that right now, but it could come in useful.

This also includes a couple minor fixes.