### PR TITLE
schema: Add version to issue ID fields

### DIFF
--- a/kcidb_io/schema/v04_01.py
+++ b/kcidb_io/schema/v04_01.py
@@ -904,6 +904,6 @@ class Version(PreviousVersion):
         checkouts=dict(id=str),
         builds=dict(id=str),
         tests=dict(id=str),
-        issues=dict(id=str),
+        issues=dict(id=str, version=int),
         incidents=dict(id=str),
     )


### PR DESCRIPTION
Add the "version" field to "issues" ID description, since it's the combination of both the "id" and the "version" field which identifies the "issue" object uniquely.