### PR TITLE
schema: Assume v1 is v1.1 as before

### DIFF
--- a/kcidb_io/schema/v01_01.py
+++ b/kcidb_io/schema/v01_01.py
@@ -603,7 +603,7 @@ class Version(AbstractVersion):
             if isinstance(version, str):
                 match = re.match("^([0-9]+)(\\.([0-9]+))?$", version)
                 if match:
-                    return int(match.group(1)), int(match.group(3) or "0")
+                    return int(match.group(1)), int(match.group(3) or "1")
             else:
                 major = version["major"]
                 try:


### PR DESCRIPTION
When presented with I/O data containing `"version": "1"`, assume it's actually v1.1, as that's what KernelCI legacy means, and that's what KCIDB accepted it as in the past.