### PR TITLE
pyproject: pin deps to versions buildable on python 3.10 through 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "jsonschema[format]",
+    "jsonschema[format]>=4.26.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "flake8",
-    "pylint",
-    "pytest",
+    "pylint>=0.22",
+    "pytest>=2.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add minimum version pins to packages that do not build on supported python versions.

## Tests
I tested that these are the minimum versions that build under python 3.10 through 3.14 using `uv sync --resolution lowest-direct`. I *did not* test any runtime behavior on these versions. I also did not test that transitive dependencies build on these python versions.

`jsonschema>=4.26.0` was an exception. It is not the earliest buildable jsonschema version, but it fixes a similar issue for its `rdps-py` dependency for python 3.14, so using it avoids at least one transitive dependency issue for python 3.14 compatibility.